### PR TITLE
Replace rdfind with internal xxhash-based duplicate finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The script relies on a few external programs:
 
 - `libimage-exiftool-perl` (provides `exiftool`)
 - `xxhash` (provides `xxhsum`)
-- `rdfind`
 - `inotify-tools` (required only for `--watch` mode)
 - standard Unix tools such as `sort`, `du` and `df`
+
+For metadata deduplication an internal script `xxrdfind.py` (based on
+xxhash64) is included, removing the need for the external `rdfind` utility.
 
 To automatically install missing packages run:
 
@@ -22,8 +24,8 @@ To automatically install missing packages run:
 
 - `-r, --recursive` – recurse into subdirectories
 - `-d, --ddwometadata` – raw dedupe by XXH64 between source and destination
-- `-D, --deldupi` – metadata dedupe by rdfind on source
-- `-X, --deldupidest` – metadata dedupe by rdfind on destination
+- `-D, --deldupi` – metadata dedupe by bundled xxhash scanner on source
+- `-X, --deldupidest` – metadata dedupe by bundled xxhash scanner on destination
 - `-y, --year-month-sort` – sort into `Year/Month` directories (default on)
 - `-Y, --check-year-mount` – verify that the current year's folder under the
   destination exists and is a mountpoint

--- a/xxrdfind.py
+++ b/xxrdfind.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+xxrdfind.py - xxhash64-based duplicate finder with logging, dry-run, 
+multithreading and progress display. Designed as a lightweight replacement for
+rdfind for use within rog-syncobra.
+
+Usage:
+    ./xxrdfind.py [options] DIR [DIR ...]
+
+Options:
+    --delete        Remove duplicate files, keeping first instance.
+    --dry-run       Show actions without deleting files.
+    --threads N     Number of hashing worker threads (default: CPU count).
+    --log-level L   Logging level (DEBUG, INFO, WARNING; default INFO).
+    --no-progress   Disable progress bar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+import os
+import xxhash
+from tqdm import tqdm
+
+CHUNK_SIZE = 1 << 20  # 1 MB
+
+logger = logging.getLogger("xxrdfind")
+
+
+def file_hash(path: Path) -> tuple[Path, str]:
+    h = xxhash.xxh64()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(CHUNK_SIZE), b""):
+            h.update(chunk)
+    return path, h.hexdigest()
+
+
+def iter_files(paths):
+    for p in paths:
+        if p.is_file():
+            yield p
+        elif p.is_dir():
+            for sub in p.rglob('*'):
+                if sub.is_file():
+                    yield sub
+
+
+def find_duplicates(paths, delete=False, dry_run=False, threads=None, show_progress=True):
+    size_map = defaultdict(list)
+    all_files = list(iter_files(paths))
+    for f in all_files:
+        try:
+            size_map[f.stat().st_size].append(f)
+        except OSError as e:
+            logger.warning("Skipping %s: %s", f, e)
+
+    candidates = [group for group in size_map.values() if len(group) > 1]
+    files_to_hash = [f for group in candidates for f in group]
+
+    hash_map = defaultdict(list)
+    if threads is None or threads < 1:
+        threads = os.cpu_count() or 1
+
+    progress = tqdm(total=len(files_to_hash), unit="file", disable=not show_progress)
+    with ThreadPoolExecutor(max_workers=threads) as ex:
+        for path, digest in ex.map(file_hash, files_to_hash):
+            hash_map[digest].append(path)
+            progress.update(1)
+    progress.close()
+
+    dup_groups = [group for group in hash_map.values() if len(group) > 1]
+    for group in dup_groups:
+        group_sorted = sorted(group)
+        logger.info("Duplicates: %s", ", ".join(str(p) for p in group_sorted))
+        if delete:
+            for f in group_sorted[1:]:
+                if dry_run:
+                    logger.info("Would delete %s", f)
+                else:
+                    try:
+                        f.unlink()
+                        logger.info("Deleted %s", f)
+                    except OSError as e:
+                        logger.error("Failed to delete %s: %s", f, e)
+
+
+def main():
+    p = argparse.ArgumentParser(description="xxhash64 duplicate finder")
+    p.add_argument('paths', nargs='+', type=Path, help="Directories/files to scan")
+    p.add_argument('--delete', action='store_true', help="Delete duplicates")
+    p.add_argument('--dry-run', action='store_true', help="Dry run")
+    p.add_argument('--threads', type=int, default=0, help="Worker threads")
+    p.add_argument('--log-level', default='INFO', help="Logging level")
+    p.add_argument('--no-progress', action='store_true', help="Disable progress bar")
+    args = p.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO),
+                        format='%(levelname)s: %(message)s')
+
+    find_duplicates(args.paths, delete=args.delete, dry_run=args.dry_run,
+                    threads=args.threads, show_progress=not args.no_progress)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `xxrdfind.py`, a multithreaded xxhash64 duplicate finder with logging, dry-run, and progress bar
- use new script for metadata dedupe instead of external rdfind
- update README and options to describe built-in scanner

## Testing
- `python -m py_compile xxrdfind.py rog-syncobra.py`
- `python xxrdfind.py --help`
- `python rog-syncobra.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c5ebbac290832581039bd879a019a3