### PR TITLE
Add metadata-stripping dedupe via xxrdfind

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ The script relies on a few external programs:
 - `inotify-tools` (required only for `--watch` mode)
 - standard Unix tools such as `sort`, `du` and `df`
 
-For metadata deduplication an internal script `xxrdfind.py` (based on
-xxhash64) is included, removing the need for the external `rdfind` utility.
+For metadata or raw-data deduplication an internal script `xxrdfind.py`
+(based on xxhash64) is included, removing the need for the external
+`rdfind` utility.  Using its `--strip-metadata` option allows deduplication
+based solely on media content.
 
 To automatically install missing packages run:
 
@@ -33,7 +35,6 @@ To automatically install missing packages run:
 - `-w, --whatsapp` – enable WhatsApp media handling
 - `-n, --dry-run` – show actions without executing them
 - `--debug` – verbose exiftool output
-- `--verify-before-delete` – rehash files before removing duplicates
 - `-W, --watch` – watch mode; monitor for `CLOSE_WRITE` events
 - `-I, --inputdir DIR` – directory to watch/process (default: current directory)
 - `-g, --grace SECONDS` – seconds to wait after `close_write` (default: 300)


### PR DESCRIPTION
## Summary
- allow xxrdfind to hash files with metadata removed via `--strip-metadata`
- route rog-syncobra dedupe through xxrdfind, using the metadata-stripping mode for `--ddwometadata`
- document xxrdfind's `--strip-metadata` option and drop unused verify-before-delete flag

## Testing
- `python -m py_compile xxrdfind.py rog-syncobra.py`
- `python xxrdfind.py --help`
- `python rog-syncobra.py --help | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68c5eeaadc9c8325b59f97e3f2596c35