### PR TITLE
Handle timezone in A059P timestamp fix

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -284,7 +284,8 @@ def exif_sort(src, dest, args):
     cmd = [
         'exiftool', vflag, *recur,
         '-if', "$AndroidModel eq 'A059P'",
-        '-alldates<FileModifyDate',
+        '-d', '%Y:%m:%d %H:%M:%S',
+        '-alldates<${FileModifyDate#}',
         '-overwrite_original_in_place','-P','-fast2',
         '-ext+','MP4','-ext+','MOV','-ext+','MTS','-ext+','MPG',
         '-ext+','VOB','-ext+','3GP','-ext+','AVI','.'


### PR DESCRIPTION
## Summary
- avoid Reconyx "Too many values specified" warning when fixing A059P timestamps

## Testing
- `python -m py_compile rog-syncobra.py`
- `python rog-syncobra.py --help`
- `exiftool -d '%Y:%m:%d %H:%M:%S' '-alldates<${FileModifyDate#}' dummy.mp4`

------
https://chatgpt.com/codex/tasks/task_e_68c5f88d4ba88325a0c6587d48302b1a