### PR TITLE
Use BLAKE2b to confirm xxhash duplicate candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The script relies on a few external programs:
 - standard Unix tools such as `sort`, `du` and `df`
 
 For metadata or raw-data deduplication an internal script `xxrdfind.py`
-(based on xxhash64) is included, removing the need for the external
-`rdfind` utility.  Using its `--strip-metadata` option allows deduplication
-based solely on media content.
+(xxhash64 with BLAKE2b confirmation) is included, removing the need for the
+external `rdfind` utility. Using its `--strip-metadata` option allows
+deduplication based solely on media content.
 
 To automatically install missing packages run:
 


### PR DESCRIPTION
## Summary
- confirm xxhash64 matches with strong BLAKE2b hashing before acting on duplicates
- document xxrdfind's two-stage hashing approach

## Testing
- `python -m py_compile xxrdfind.py && ls __pycache__ && rm -r __pycache__`
- `python xxrdfind.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c6015dc17c8325883a610eead7ae93