### PR TITLE
Correct exiftool quoting for AndroidModel timestamp fix

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -268,7 +268,7 @@ def exif_sort(src, dest, args):
             '-if','$Keywords=~/whatsapp/i',
             '-FileName<${CreateDate} ${Keywords}%-c.%e',
             '-d', "%Y-%m-%d %H-%M-%S",
-            '-ext+','JPG','-ext+','MP4','-ext+','3GP','.'
+            '-ext','JPG','-ext','MP4','-ext','3GP','.'
         ]
         run(cmd)
         cmd = [
@@ -283,12 +283,12 @@ def exif_sort(src, dest, args):
     logger.info("AndroidModel A059P timestamp fix")
     cmd = [
         'exiftool', vflag, *recur,
-        '-if', "$AndroidModel eq 'A059P'",
+        '-if', '$AndroidModel eq "A059P"',
         '-d', '%Y:%m:%d %H:%M:%S',
         '-alldates<${FileModifyDate#}',
         '-overwrite_original_in_place','-P','-fast2',
-        '-ext+','MP4','-ext+','MOV','-ext+','MTS','-ext+','MPG',
-        '-ext+','VOB','-ext+','3GP','-ext+','AVI','.'
+        '-ext','MP4','-ext','MOV','-ext','MTS','-ext','MPG',
+        '-ext','VOB','-ext','3GP','-ext','AVI','.'
     ]
     run(cmd)
 
@@ -305,7 +305,7 @@ def exif_sort(src, dest, args):
         '-Filename<${CreateDate}_$SubSecTimeOriginal ${model;}%-c.%e',
         '-Filename<${CreationDate}_$SubSecTimeOriginal ${model;}%-c.%e',
         '-d', f"{dest}/{ym}/%Y-%m-%d %H-%M-%S",
-        '-ext+','MPG','-ext+','MTS','-ext+','VOB','-ext+','3GP','-ext+','AVI',
+        '-ext','MPG','-ext','MTS','-ext','VOB','-ext','3GP','-ext','AVI',
         '-ee','.'
     ]
     run(cmd)


### PR DESCRIPTION
## Summary
- Quote `$AndroidModel` check and list extensions with `-ext` so exiftool handles A059P timestamp updates
- Use `-ext` flags consistently across WhatsApp and DCIM processing commands

## Testing
- `python rog-syncobra.py --help`
- `python -m py_compile rog-syncobra.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6970dd2208325a00bdecd2009bc80