### PR TITLE
Parallelize exiftool processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To automatically install missing packages run:
 - `-w, --whatsapp` – enable WhatsApp media handling
 - `-n, --dry-run` – show actions without executing them
 - `--debug` – verbose exiftool output
+- `--exiftool-workers N` – run exiftool with up to `N` parallel workers (default: auto)
 - `-W, --watch` – watch mode; monitor for `CLOSE_WRITE` events
 - `-I, --inputdir DIR` – directory to watch/process (default: current directory)
 - `-g, --grace SECONDS` – seconds to wait after `close_write` (default: 300)


### PR DESCRIPTION
## Summary
- add a configurable worker pool that runs exiftool in parallel chunks to speed up processing
- expose the worker count via a new --exiftool-workers option and document it in the README

## Testing
- python -m compileall rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cc7e23d1ac8325b3bb3c69718be5f6