### PR TITLE
Add skip marker support for exiftool processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To automatically install missing packages run:
 - `-g, --grace SECONDS` – seconds to wait after `close_write` (default: 300)
 - `--archive-dir DIR` – directory to archive old files to
 - `--archive-years YEARS` – move directories older than this many years (default: 2)
+- `--skip-marker NAME` – skip directories that contain `NAME` (default: `.rog-syncobraignore`; set to an empty string to disable)
 - `--install-deps` – install required system packages and exit
 
 ## Systemd service


### PR DESCRIPTION
## Summary
- add a configurable `--skip-marker` option and honor marker files while building exiftool targets
- ensure the media scan ignores excluded directories so marker-protected folders do not trigger work
- document the opt-out marker in the options list

## Testing
- python -m compileall rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd00cc83ec8325b186eb056d57a369