### PR TITLE
Run metadata dedupe before raw dedupe when both flags set

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ To automatically install missing packages run:
 
 - `-r, --recursive` – recurse into subdirectories
 - `-d, --ddwometadata` – raw dedupe by XXH64 between source and destination
-- `-D, --deldupi` – metadata dedupe by bundled xxhash scanner on source
+- `-D, --deldupi` – metadata dedupe by bundled xxhash scanner on source (runs before
+  `--ddwometadata` so the lighter metadata pass can remove duplicates before the
+  raw scan)
 - `-X, --dedupsourceanddest` – metadata dedupe on source, then compare against destination
 - `-y, --year-month-sort` – sort into `Year/Month` directories (default on)
 - `-Y, --check-year-mount` – verify that the current year's folder under the

--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -734,13 +734,15 @@ def pipeline(args):
         check_year_mount(dest)
     check_disk_space(src, dest, args.dry_run)
     ran_source_dedupe = False
-    if args.dedupsourceanddest:
+    if args.deldupi:
         metadata_dedupe(src, args.dry_run)
         ran_source_dedupe = True
+    if args.dedupsourceanddest:
+        if not ran_source_dedupe:
+            metadata_dedupe(src, args.dry_run)
+            ran_source_dedupe = True
         if dest_abs != src_abs:
             metadata_dedupe_source_against_dest(src, dest, args.dry_run)
-    if args.deldupi and not ran_source_dedupe:
-        metadata_dedupe(src, args.dry_run)
     if args.ddwometadata:
         raw_dedupe(src, dest, args.dry_run)
     exif_sort(src, dest, args)


### PR DESCRIPTION
## Summary
- run the metadata-based `--deldupi` pass before invoking raw `--ddwometadata` dedupe
- document that the metadata sweep happens first so cheaper scans can discard duplicates early

## Testing
- python -m compileall rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd144e69408325b57ca7d9e3185ba1