### PR TITLE
Normalize ExifTool ready sentinel handling

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -458,7 +458,7 @@ def exif_sort(src, dest, args):
                     line = proc.stdout.readline()
                     if not line:
                         raise RuntimeError('exiftool terminated unexpectedly')
-                    line = line.rstrip()
+                    line = line.strip()
                     if line == '{ready}':
                         break
                     if line.lower().startswith('error'):


### PR DESCRIPTION
## Summary
- normalize ExifTool worker loop output lines before checking the `{ready}` sentinel so whitespace does not block shutdown

## Testing
- PATH="/tmp:$PATH" python rog-syncobra.py --inputdir /tmp/testdir --move2targetdir /tmp/testdir


------
https://chatgpt.com/codex/tasks/task_e_68cd211ee0388325aed453e3c82585d8