### PR TITLE
Add optional Photoprism indexing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ To automatically install missing packages run:
 - `-F, --dedup-destination-final` – run metadata dedupe on the destination after the
   pipeline finishes moving files
 - `--install-deps` – install required system packages and exit
+- `--photoprism-index-command CMD` – run `CMD` via `/bin/sh -c` after changes are
+  made so Photoprism can index new or removed files; failed runs are retried on the
+  next invocation
 
 ## Systemd service
 An example systemd **template** unit is provided in `rog-syncobra@.service`. It


### PR DESCRIPTION
## Summary
- add persistent queue that can trigger a configurable Photoprism indexing command after media changes
- expose a new --photoprism-index-command flag and document it in the README
- make exif_sort report when work was done so the queue runs only after actual changes

## Testing
- python -m py_compile rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3b230e54832590946cba66f6bc6e