### PR TITLE
Support kubectl-friendly Photoprism commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,23 @@ To automatically install missing packages run:
   made so Photoprism can index new or removed files; failed runs are retried on the
   next invocation. The placeholders `{path}`, `{relative}`, and `{dest}` expand to
   the absolute directory path, the path relative to the destination root, and the
-  destination root respectively.
+  destination root respectively. Appending `_q` (for example `{path_q}`) inserts a
+  shell-quoted version suitable for commands such as `kubectl exec`.
+
+### Photoprism index examples
+
+Trigger Photoprism directly for each affected directory:
+
+```bash
+./rog-syncobra.py --photoprism-index-command "photoprism index -f -c {path_q}"
+```
+
+Run indexing inside a Kubernetes-managed Photoprism instance:
+
+```bash
+./rog-syncobra.py --photoprism-index-command \
+  "kubectl exec --stdin --tty -n photoprism pod/photoprism-0 -- photoprism index -f -c {path_q}"
+```
 
 ## Systemd service
 An example systemd **template** unit is provided in `rog-syncobra@.service`. It


### PR DESCRIPTION
## Summary
- add shell-quoted Photoprism placeholder expansions so commands like kubectl exec work
- clarify the CLI help and README with the new placeholders and usage examples

## Testing
- python -m py_compile rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd440c534483259822f95863db0e23