### PR TITLE
Improve Photoprism API logging and add API-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ To automatically install missing packages run:
   API instead of executing a local command. Optional flags `--photoprism-api-rescan`
   and `--photoprism-api-cleanup` request a full rescan or cleanup cycle,
   respectively. Use `--photoprism-api-insecure` to skip TLS verification when
-  working with self-signed certificates.
+  working with self-signed certificates. Use `--photoprism-api-call [PATH]` to
+  trigger the API manually (defaulting to `/`) and exit without performing any
+  file processing.
 
 ### Photoprism index examples
 


### PR DESCRIPTION
## Summary
- include response body and authentication headers when Photoprism API calls fail and add debug traces for login/index requests
- introduce a --photoprism-api-call flag to trigger the Photoprism API without running the processing pipeline
- document the new flag in the README

## Testing
- python -m compileall rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd51938f8c8325b41da22f74f67605