### PR TITLE
Skip Photoprism API indexing for source paths

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -454,9 +454,16 @@ def handle_photoprism_index(
         path_value = ''
         if dest_root_path is not None:
             try:
-                path_value = str(target.relative_to(dest_root_path))
+                relative = target.relative_to(dest_root_path)
             except ValueError:
-                path_value = str(target)
+                logger.debug(
+                    "Skipping Photoprism target outside library root: %s",
+                    target,
+                )
+                continue
+            path_value = str(relative)
+            if path_value == '.':
+                path_value = ''
         else:
             path_value = str(target)
         path_value = path_value or '/'


### PR DESCRIPTION
## Summary
- ignore Photoprism indexing targets that fall outside the configured library root
- normalize the relative path for the library root itself so the API receives the root path

## Testing
- python -m py_compile rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd5eb9f5e8832599f5506a74cd229f