### PR TITLE
Add Photoprism API path prefix stripping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ To automatically install missing packages run:
   API instead of executing a local command. Optional flags `--photoprism-api-rescan`
   and `--photoprism-api-cleanup` request a full rescan or cleanup cycle,
   respectively. Use `--photoprism-api-insecure` to skip TLS verification when
-  working with self-signed certificates. Use `--photoprism-api-call [PATH]` to
-  trigger the API manually (defaulting to `/`) and exit without performing any
-  file processing.
+  working with self-signed certificates. Use `--photoprism-api-strip-prefix`
+  one or more times to remove prefixes (for example host mount points) from
+  paths before they are submitted to the API. Use `--photoprism-api-call [PATH]`
+  to trigger the API manually (defaulting to `/`) and exit without performing
+  any file processing.
 
 ### Photoprism index examples
 


### PR DESCRIPTION
## Summary
- add a configurable list of prefixes to strip from Photoprism API paths before triggering an index
- derive API path display roots from the configured destination/input paths so the API sees the expected directory structure
- document the new `--photoprism-api-strip-prefix` CLI flag in the README

## Testing
- python3 -m py_compile rog-syncobra.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6495d4b88325b8b3f479a7c3f233