### PR TITLE
Update Photoprism indexing targets

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -174,11 +174,7 @@ class OperationTracker:
             if str(candidate):
                 targets.add(candidate)
 
-        for src, dest in self.moved:
-            src_parent = Path(src).parent
-            if str(src_parent):
-                targets.add(src_parent)
-
+        for _src, dest in self.moved:
             dest_path = Path(dest)
             dest_candidate = dest_path if not dest_path.suffix else dest_path.parent
             if str(dest_candidate):


### PR DESCRIPTION
## Summary
- stop adding source directories from move operations to the Photoprism reindex target list so only destination paths are queued

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6953247c8325a7aef0dcc4ea5b4b