### PR TITLE
Add systemd unit for PhotoPrism watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ Additional flags mirror the Photoprism options available in `rog-syncobra.py`:
 
 The watcher writes detailed logs to `/var/log/rog-syncobra/photoprism-watcher.log`.
 
+When installed through `install.sh` a systemd template unit
+`photoprism-watcher@.service` is also available. Copy
+`/etc/rog-syncobra/photoprism-watcher.conf.example` to
+`/etc/rog-syncobra/photoprism-watcher-<name>.conf`, adjust it to your
+environment, and enable the watcher with:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now photoprism-watcher@<name>.service
+```
+
 ## Installation
 
 The repository ships with an `install.sh` helper that copies the Python

--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,13 @@ else
     echo "Installed systemd unit -> $SYSTEMD_DIR/rog-syncobra@.service"
 fi
 
+install_file 644 "photoprism-watcher@.service" "$SYSTEMD_DIR/photoprism-watcher@.service"
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "[dry-run] Would install PhotoPrism watcher unit -> $SYSTEMD_DIR/photoprism-watcher@.service"
+else
+    echo "Installed PhotoPrism watcher unit -> $SYSTEMD_DIR/photoprism-watcher@.service"
+fi
+
 install_file 644 "README.md" "$SHARE_DIR/README.md"
 if [[ $DRY_RUN -eq 1 ]]; then
     echo "[dry-run] Would install documentation -> $SHARE_DIR/README.md"
@@ -142,6 +149,13 @@ if [[ $DRY_RUN -eq 1 ]]; then
     echo "[dry-run] Would create configuration example -> $CONFIG_DIR/rog-syncobra.conf.example"
 else
     echo "Configuration example -> $CONFIG_DIR/rog-syncobra.conf.example"
+fi
+
+install_file 644 "photoprism-watcher.conf.example" "$CONFIG_DIR/photoprism-watcher.conf.example"
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "[dry-run] Would install watcher configuration example -> $CONFIG_DIR/photoprism-watcher.conf.example"
+else
+    echo "Watcher configuration example -> $CONFIG_DIR/photoprism-watcher.conf.example"
 fi
 
 echo

--- a/photoprism-watcher.conf.example
+++ b/photoprism-watcher.conf.example
@@ -1,0 +1,32 @@
+# Example configuration for photoprism-watcher@.service instances
+# Copy this file to /etc/rog-syncobra/photoprism-watcher-example.conf,
+# adjust the values, and enable it with:
+#   systemctl enable --now photoprism-watcher@example.service
+
+# Directory tree to watch for new media (expects YYYY/MM subdirectories)
+WATCH_DIR=/srv/media/library/originals
+
+# Root of the PhotoPrism originals library that should be indexed
+DEST_ROOT=/srv/media/library/originals
+
+# Base URL of the PhotoPrism API (usually ends with /api/v1)
+PHOTOPRISM_API_BASE_URL=https://photos.example.com/api/v1
+
+# Provide either API credentials or a pre-generated access token.
+PHOTOPRISM_API_USERNAME=admin
+PHOTOPRISM_API_PASSWORD=supersecret
+# PHOTOPRISM_API_TOKEN=
+
+# Set to 1 to skip TLS verification for self-signed certificates
+# PHOTOPRISM_API_INSECURE=1
+
+# Optional tuning parameters
+# MIN_SECONDS_BETWEEN_INDEX=300
+# MAX_QUEUE_LAG=300
+
+# Enable verbose logging or dry-run mode by setting these to 1
+# VERBOSE=1
+# DRY_RUN=1
+
+# Additional command-line arguments (space separated), e.g.:
+# EXTRA_ARGS="--initial-index"

--- a/photoprism-watcher@.service
+++ b/photoprism-watcher@.service
@@ -1,0 +1,50 @@
+[Unit]
+Description=rog-syncobra PhotoPrism watcher (%i)
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/rog-syncobra/photoprism-watcher-%i.conf
+ExecStart=/usr/bin/env bash -c "set -euo pipefail; \
+  ARGS=(/usr/bin/env python3 /usr/local/bin/photoprism-watcher.py \
+    --watch-dir \"${WATCH_DIR:?Set WATCH_DIR in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
+    --dest-root \"${DEST_ROOT:?Set DEST_ROOT in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
+    --pp-base-url \"${PHOTOPRISM_API_BASE_URL:?Set PHOTOPRISM_API_BASE_URL in /etc/rog-syncobra/photoprism-watcher-%i.conf}\"\
+  ); \
+  if [[ -n \"${PHOTOPRISM_API_USERNAME:-}\" ]]; then \
+    ARGS+=(--pp-user \"${PHOTOPRISM_API_USERNAME}\"); \
+  fi; \
+  if [[ -n \"${PHOTOPRISM_API_PASSWORD:-}\" ]]; then \
+    ARGS+=(--pp-pass \"${PHOTOPRISM_API_PASSWORD}\"); \
+  fi; \
+  if [[ -n \"${PHOTOPRISM_API_TOKEN:-}\" ]]; then \
+    ARGS+=(--token \"${PHOTOPRISM_API_TOKEN}\"); \
+  fi; \
+  if [[ \"${PHOTOPRISM_API_INSECURE:-0}\" == \"1\" ]]; then \
+    ARGS+=(--insecure); \
+  fi; \
+  if [[ -n \"${MIN_SECONDS_BETWEEN_INDEX:-}\" ]]; then \
+    ARGS+=(--min-seconds-between-index \"${MIN_SECONDS_BETWEEN_INDEX}\"); \
+  fi; \
+  if [[ -n \"${MAX_QUEUE_LAG:-}\" ]]; then \
+    ARGS+=(--max-queue-lag \"${MAX_QUEUE_LAG}\"); \
+  fi; \
+  if [[ \"${DRY_RUN:-0}\" == \"1\" ]]; then \
+    ARGS+=(--dry-run); \
+  fi; \
+  if [[ \"${VERBOSE:-0}\" == \"1\" ]]; then \
+    ARGS+=(--verbose); \
+  fi; \
+  if [[ -n \"${EXTRA_ARGS:-}\" ]]; then \
+    read -r -a extra <<< \"${EXTRA_ARGS}\"; \
+    ARGS+=(\"${extra[@]}\"); \
+  fi; \
+  exec \"${ARGS[@]}\""
+Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=photoprism-watcher@%i
+LogsDirectory=rog-syncobra
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a systemd template unit for photoprism-watcher.py with environment-driven configuration
- install the new unit and example configuration alongside existing artifacts
- document how to enable the PhotoPrism watcher service after installation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ecdbc09c8325a458b087dc8bbfe6