### PR TITLE
Skip exiftool for unsupported video files when stripping metadata

### DIFF
--- a/test_xxrdfind.py
+++ b/test_xxrdfind.py
@@ -1,0 +1,56 @@
+import sys
+import tempfile
+import types
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+if "xxhash" not in sys.modules:
+    class _DummyHash:
+        def update(self, _):
+            pass
+
+        def hexdigest(self):
+            return "dummy"
+
+    xxhash_stub = types.SimpleNamespace(xxh64=lambda: _DummyHash())
+    sys.modules["xxhash"] = xxhash_stub
+
+if "tqdm" not in sys.modules:
+    tqdm_module = types.ModuleType("tqdm")
+
+    class _DummyTqdm:
+        def __init__(self, *_, **__):
+            pass
+
+        def update(self, *_args, **_kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    def _tqdm(*_args, **_kwargs):
+        return _DummyTqdm()
+
+    tqdm_module.tqdm = _tqdm
+    sys.modules["tqdm"] = tqdm_module
+
+import xxrdfind
+
+
+class FileHashTest(TestCase):
+    def test_skips_exiftool_for_unsupported_video_when_stripping_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            video_path = Path(tmp) / "example.mkv"
+            video_path.write_bytes(b"data")
+
+            with patch("xxrdfind.subprocess.Popen") as popen_mock:
+                with self.assertLogs("xxrdfind", level="INFO") as logs:
+                    result = xxrdfind.file_hash(video_path, strip_metadata=True)
+
+            self.assertEqual((video_path, None), result)
+            popen_mock.assert_not_called()
+            self.assertTrue(
+                any("skipping raw dedupe for" in message for message in logs.output),
+                logs.output,
+            )

--- a/xxrdfind.py
+++ b/xxrdfind.py
@@ -36,6 +36,15 @@ from tqdm import tqdm
 
 CHUNK_SIZE = 1 << 20  # 1 MB
 
+UNSUPPORTED_EXIFTOOL_VIDEO_EXTENSIONS = {
+    ".mkv",
+    ".avi",
+    ".wmv",
+    ".mts",
+    ".m2ts",
+    ".vob",
+}
+
 logger = logging.getLogger("xxrdfind")
 
 
@@ -86,6 +95,10 @@ def file_hash(path: Path, strip_metadata: bool = False, algorithm: str = 'xxh64'
         raise ValueError(f"Unsupported algorithm: {algorithm}")
     try:
         if strip_metadata:
+            suffix = path.suffix.lower()
+            if suffix in UNSUPPORTED_EXIFTOOL_VIDEO_EXTENSIONS:
+                logger.info("skipping raw dedupe for %s", path)
+                return path, None
             cmd = ['exiftool', '-all=', '-o', '-', str(path)]
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
             assert proc.stdout is not None


### PR DESCRIPTION
## Summary
- skip the exiftool call for known unsupported video extensions when stripping metadata
- log the skip and return no hash so raw dedupe ignores the file
- add a regression test that ensures unsupported videos bypass exiftool

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f896e8008325a9bb7c9c05d49098