### PR TITLE
Fix photoprism watcher systemd variable expansion

### DIFF
--- a/photoprism-watcher@.service
+++ b/photoprism-watcher@.service
@@ -7,39 +7,39 @@ Type=simple
 EnvironmentFile=/etc/rog-syncobra/photoprism-watcher-%i.conf
 ExecStart=/usr/bin/env bash -c "set -euo pipefail; \
   ARGS=(/usr/bin/env python3 /usr/local/bin/photoprism-watcher.py \
-    --watch-dir \"${WATCH_DIR:?Set WATCH_DIR in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
-    --dest-root \"${DEST_ROOT:?Set DEST_ROOT in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
-    --pp-base-url \"${PHOTOPRISM_API_BASE_URL:?Set PHOTOPRISM_API_BASE_URL in /etc/rog-syncobra/photoprism-watcher-%i.conf}\"\
+    --watch-dir \"$${WATCH_DIR:?Set WATCH_DIR in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
+    --dest-root \"$${DEST_ROOT:?Set DEST_ROOT in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
+    --pp-base-url \"$${PHOTOPRISM_API_BASE_URL:?Set PHOTOPRISM_API_BASE_URL in /etc/rog-syncobra/photoprism-watcher-%i.conf}\"\
   ); \
-  if [[ -n \"${PHOTOPRISM_API_USERNAME:-}\" ]]; then \
-    ARGS+=(--pp-user \"${PHOTOPRISM_API_USERNAME}\"); \
+  if [[ -n \"$${PHOTOPRISM_API_USERNAME:-}\" ]]; then \
+    ARGS+=(--pp-user \"$${PHOTOPRISM_API_USERNAME}\"); \
   fi; \
-  if [[ -n \"${PHOTOPRISM_API_PASSWORD:-}\" ]]; then \
-    ARGS+=(--pp-pass \"${PHOTOPRISM_API_PASSWORD}\"); \
+  if [[ -n \"$${PHOTOPRISM_API_PASSWORD:-}\" ]]; then \
+    ARGS+=(--pp-pass \"$${PHOTOPRISM_API_PASSWORD}\"); \
   fi; \
-  if [[ -n \"${PHOTOPRISM_API_TOKEN:-}\" ]]; then \
-    ARGS+=(--token \"${PHOTOPRISM_API_TOKEN}\"); \
+  if [[ -n \"$${PHOTOPRISM_API_TOKEN:-}\" ]]; then \
+    ARGS+=(--token \"$${PHOTOPRISM_API_TOKEN}\"); \
   fi; \
-  if [[ \"${PHOTOPRISM_API_INSECURE:-0}\" == \"1\" ]]; then \
+  if [[ \"$${PHOTOPRISM_API_INSECURE:-0}\" == \"1\" ]]; then \
     ARGS+=(--insecure); \
   fi; \
-  if [[ -n \"${MIN_SECONDS_BETWEEN_INDEX:-}\" ]]; then \
-    ARGS+=(--min-seconds-between-index \"${MIN_SECONDS_BETWEEN_INDEX}\"); \
+  if [[ -n \"$${MIN_SECONDS_BETWEEN_INDEX:-}\" ]]; then \
+    ARGS+=(--min-seconds-between-index \"$${MIN_SECONDS_BETWEEN_INDEX}\"); \
   fi; \
-  if [[ -n \"${MAX_QUEUE_LAG:-}\" ]]; then \
-    ARGS+=(--max-queue-lag \"${MAX_QUEUE_LAG}\"); \
+  if [[ -n \"$${MAX_QUEUE_LAG:-}\" ]]; then \
+    ARGS+=(--max-queue-lag \"$${MAX_QUEUE_LAG}\"); \
   fi; \
-  if [[ \"${DRY_RUN:-0}\" == \"1\" ]]; then \
+  if [[ \"$${DRY_RUN:-0}\" == \"1\" ]]; then \
     ARGS+=(--dry-run); \
   fi; \
-  if [[ \"${VERBOSE:-0}\" == \"1\" ]]; then \
+  if [[ \"$${VERBOSE:-0}\" == \"1\" ]]; then \
     ARGS+=(--verbose); \
   fi; \
-  if [[ -n \"${EXTRA_ARGS:-}\" ]]; then \
-    read -r -a extra <<< \"${EXTRA_ARGS}\"; \
-    ARGS+=(\"${extra[@]}\"); \
+  if [[ -n \"$${EXTRA_ARGS:-}\" ]]; then \
+    read -r -a extra <<< \"$${EXTRA_ARGS}\"; \
+    ARGS+=(\"$${extra[@]}\"); \
   fi; \
-  exec \"${ARGS[@]}\""
+  exec \"$${ARGS[@]}\""
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary
- escape bash variable references in the systemd unit so systemd does not try to expand them itself
- ensure optional environment variables can be left unset without systemd complaining

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41b6be7e48325a66383ee5cf8925b