### PR TITLE
Expand watch input directory path

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1014,6 +1014,7 @@ def main():
         check_program(cmd)
     if args.watch:
         check_program('inotifywait')
+        args.inputdir = _expand_path(args.inputdir)
         pipeline(args)
         logger.info(f"Entering watch mode on {args.inputdir}")
         while True:


### PR DESCRIPTION
## Summary
- expand the watch input directory when enabling watch mode so inotify receives an absolute path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4636e22348325b581eccc647608b1