### PR TITLE
Run daemon-reload during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,7 @@ echo
 if [[ $DRY_RUN -eq 1 ]]; then
     echo "Dry-run complete. No changes were made."
 else
+    systemctl daemon-reload
     cat <<EOM
 Installation complete.
 Next steps:


### PR DESCRIPTION
## Summary
- invoke `systemctl daemon-reload` during installation so new unit files are registered immediately

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d538a3104083259ffea43a0c6f5a8c