### PR TITLE
Allow inline comments in env bools

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -261,7 +261,13 @@ ENV_VALUE_FLAGS: dict[str, dict[str, Union[str, bool]]] = {
 
 
 def _parse_env_bool(value: str) -> Union[bool, None]:
-    lowered = value.strip().lower()
+    stripped = value.strip()
+    hash_index = stripped.find('#')
+    if hash_index != -1:
+        stripped = stripped[:hash_index].rstrip()
+    if stripped == '':
+        return None
+    lowered = stripped.lower()
     if lowered in TRUE_VALUES:
         return True
     if lowered in FALSE_VALUES:


### PR DESCRIPTION
## Summary
- strip inline comments when parsing boolean environment variables
- treat empty values as invalid and keep existing warning behavior for unrecognized tokens

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53c46824c8325999575de44ca7c1a