### PR TITLE
Add uninstall helper and support multiple watcher directories

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,12 +194,19 @@ echo
 if [[ $DRY_RUN -eq 1 ]]; then
     echo "Dry-run complete. No changes were made."
 else
-    systemctl daemon-reload
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl daemon-reload; then
+            echo "systemd daemon reloaded."
+        else
+            echo "Warning: systemctl daemon-reload failed" >&2
+        fi
+    else
+        echo "systemctl not found; skipping daemon reload."
+    fi
     cat <<EOM
 Installation complete.
 Next steps:
-  1. Run 'systemctl daemon-reload'.
-  2. Copy $CONFIG_DIR/rog-syncobra.conf.example to $CONFIG_DIR/<name>.conf and adjust paths.
-  3. Enable the service with 'systemctl enable --now rog-syncobra@<name>.service'.
+  1. Copy $CONFIG_DIR/rog-syncobra.conf.example to $CONFIG_DIR/<name>.conf and adjust paths.
+  2. Enable the service with 'systemctl enable --now rog-syncobra@<name>.service'.
 EOM
 fi

--- a/photoprism-watcher.conf.example
+++ b/photoprism-watcher.conf.example
@@ -5,6 +5,8 @@
 
 # Directory tree to watch for new media (expects YYYY/MM subdirectories)
 WATCH_DIR=/srv/media/library/originals
+# To watch multiple trees, set WATCH_DIRS to a colon-separated list, e.g.:
+# WATCH_DIRS=/srv/media/library/originals:/srv/media/archive/originals
 
 # Root of the PhotoPrism originals library that should be indexed
 DEST_ROOT=/srv/media/library/originals

--- a/photoprism-watcher@.service
+++ b/photoprism-watcher@.service
@@ -6,9 +6,21 @@ After=network.target
 Type=simple
 EnvironmentFile=/etc/rog-syncobra/photoprism-watcher-%i.conf
 ExecStart=/usr/bin/env bash -c "set -euo pipefail; \
-  ARGS=(/usr/bin/env python3 /usr/local/bin/photoprism-watcher.py \
-    --watch-dir \"$${WATCH_DIR:?Set WATCH_DIR in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
-    --dest-root \"$${DEST_ROOT:?Set DEST_ROOT in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
+  ARGS=(/usr/bin/env python3 /usr/local/bin/photoprism-watcher.py); \
+  if [[ -n \"$${WATCH_DIRS:-}\" ]]; then \
+    IFS=':' read -r -a _watch_dirs <<< \"$${WATCH_DIRS}\"; \
+  elif [[ -n \"$${WATCH_DIR:-}\" ]]; then \
+    _watch_dirs=(\"$${WATCH_DIR}\"); \
+  else \
+    echo 'WATCH_DIR or WATCH_DIRS must be set in /etc/rog-syncobra/photoprism-watcher-%i.conf' >&2; \
+    exit 1; \
+  fi; \
+  for _dir in \"$${_watch_dirs[@]}\"; do \
+    if [[ -n \"$${_dir}\" ]]; then \
+      ARGS+=(--watch-dir \"$${_dir}\"); \
+    fi; \
+  done; \
+  ARGS+=(--dest-root \"$${DEST_ROOT:?Set DEST_ROOT in /etc/rog-syncobra/photoprism-watcher-%i.conf}\" \
     --pp-base-url \"$${PHOTOPRISM_API_BASE_URL:?Set PHOTOPRISM_API_BASE_URL in /etc/rog-syncobra/photoprism-watcher-%i.conf}\"\
   ); \
   if [[ -n \"$${PHOTOPRISM_API_USERNAME:-}\" ]]; then \

--- a/test_photoprism_watcher.py
+++ b/test_photoprism_watcher.py
@@ -67,7 +67,7 @@ _normalize_pp_base_url = MODULE._normalize_pp_base_url
 class MonthEventHandlerTest(unittest.TestCase):
     def test_month_key_returns_year_month(self):
         cfg = Config(
-            watch_dir="/root/watch",
+            watch_dirs=("/root/watch",),
             dest_root="/dest",
             pp_base_url="http://example",
         )
@@ -78,11 +78,24 @@ class MonthEventHandlerTest(unittest.TestCase):
             "2025/08",
         )
 
+    def test_month_key_supports_multiple_roots(self):
+        cfg = Config(
+            watch_dirs=("/root/watch", "/mnt/photos"),
+            dest_root="/dest",
+            pp_base_url="http://example",
+        )
+        handler = MonthEventHandler(cfg, queue.Queue())
+
+        self.assertEqual(
+            handler._month_key("/mnt/photos/2023/12/img.png"),
+            "2023/12",
+        )
+
 
 class HelpersTest(unittest.TestCase):
     def test_normalizes_base_url_without_api_suffix(self):
         cfg = Config(
-            watch_dir="/root/watch",
+            watch_dirs=("/root/watch",),
             dest_root="/dest",
             pp_base_url="http://photos.example.org",
         )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX=/usr/local
+SYSTEMD_DIR=/etc/systemd/system
+CONFIG_DIR=/etc/rog-syncobra
+DRY_RUN=0
+
+print_usage() {
+    cat <<'USAGE'
+Usage: ./uninstall.sh [options]
+
+Remove rog-syncobra scripts and supporting files.
+
+Options:
+  --prefix DIR         Installation prefix for executables (default: /usr/local)
+  --systemd-dir DIR    Directory for systemd units (default: /etc/systemd/system)
+  --config-dir DIR     Directory for rog-syncobra configuration files (default: /etc/rog-syncobra)
+  --dry-run            Show the actions without making any changes
+  -h, --help           Show this help message and exit
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prefix)
+            [[ $# -ge 2 ]] || { echo "Missing argument for --prefix" >&2; exit 1; }
+            PREFIX=$2
+            shift 2
+            ;;
+        --systemd-dir)
+            [[ $# -ge 2 ]] || { echo "Missing argument for --systemd-dir" >&2; exit 1; }
+            SYSTEMD_DIR=$2
+            shift 2
+            ;;
+        --config-dir)
+            [[ $# -ge 2 ]] || { echo "Missing argument for --config-dir" >&2; exit 1; }
+            CONFIG_DIR=$2
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            print_usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "This uninstaller must be run as root." >&2
+    exit 1
+fi
+
+BIN_DIR="$PREFIX/bin"
+SHARE_DIR="$PREFIX/share/rog-syncobra"
+
+remove_path() {
+    local path=$1
+    local description=$2
+    if [[ $DRY_RUN -eq 1 ]]; then
+        printf '[dry-run] rm -f %s (%s)\n' "$path" "$description"
+        return 0
+    fi
+    if [[ -e $path ]]; then
+        rm -f "$path"
+        echo "Removed $description -> $path"
+    else
+        echo "Skipping missing $description -> $path"
+    fi
+}
+
+prune_dir_if_empty() {
+    local path=$1
+    if [[ -z $path || $path == / ]]; then
+        return 0
+    fi
+    if [[ $DRY_RUN -eq 1 ]]; then
+        printf '[dry-run] rmdir %s (if empty)\n' "$path"
+        return 0
+    fi
+    if [[ -d $path ]]; then
+        rmdir --ignore-fail-on-non-empty "$path" 2>/dev/null || true
+    fi
+}
+
+SCRIPT_FILES=(
+    "rog-syncobra.py"
+    "photoprism-watcher.py"
+    "xxrdfind.py"
+    "photoprism_api.py"
+)
+
+for script in "${SCRIPT_FILES[@]}"; do
+    remove_path "$BIN_DIR/$script" "binary"
+done
+
+remove_path "$SYSTEMD_DIR/rog-syncobra@.service" "systemd unit"
+remove_path "$SYSTEMD_DIR/photoprism-watcher@.service" "systemd unit"
+
+remove_path "$SHARE_DIR/README.md" "documentation"
+remove_path "$CONFIG_DIR/rog-syncobra.conf.example" "config example"
+remove_path "$CONFIG_DIR/photoprism-watcher.conf.example" "config example"
+
+prune_dir_if_empty "$SHARE_DIR"
+prune_dir_if_empty "$CONFIG_DIR"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "Dry-run complete. No files were removed."
+else
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl daemon-reload; then
+            echo "systemd daemon reloaded."
+        else
+            echo "Warning: systemctl daemon-reload failed" >&2
+        fi
+    else
+        echo "systemctl not found; skipping daemon reload."
+    fi
+    echo "Uninstallation complete."
+fi


### PR DESCRIPTION
## Summary
- run `systemctl daemon-reload` during installation with basic error handling instead of asking the user to do it manually
- add an `uninstall.sh` helper that removes binaries, sample configs, and reloads systemd
- update the PhotoPrism watcher, systemd unit, and sample config to support multiple watched directories and adjust tests accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d648a47ca48325b7229f715496531d