### PR TITLE
Optimize xxrdfind hashing for unique-size files

### DIFF
--- a/test_xxrdfind.py
+++ b/test_xxrdfind.py
@@ -63,6 +63,8 @@ class CacheFailureTest(TestCase):
             root = Path(tmp)
             target = root / "video.mp4"
             target.write_bytes(b"data")
+            other = root / "other.mp4"
+            other.write_bytes(b"xxxx")
 
             def fake_file_hash(path, strip_metadata=False, algorithm='xxh64'):
                 return path, None, 'exiftool failed'


### PR DESCRIPTION
## Summary
- avoid hashing files with unique sizes by grouping file metadata before scheduling work, reducing unnecessary hashing
- adjust the xxrdfind cache failure test to include a second same-sized file so the failure handling remains covered

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d64ed891c88325bb79a43bd5c676a0