### PR TITLE
Update WhatsApp video tagging to use XMP subject

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1016,16 +1016,18 @@ def exif_sort(src, dest, args):
                 cmd = [
                     'exiftool', vflag,
                     '-if', cond,
-                    '-if', 'not defined $Keywords or $Keywords!~/WhatsApp/i',
+                    '-if', 'not defined $XMP:Subject or $XMP:Subject!~/WhatsApp/i or not defined $Keywords or $Keywords!~/WhatsApp/i',
                     '-Keywords+=WhatsApp',
+                    '-XMP-dc:Subject+=WhatsApp',
                     '-alldates<20${filename}','-FileModifyDate<20${filename}',
                     '-overwrite_original_in_place','-P','-fast2', *exts
                 ]
                 queue(cmd, message=stage_message())
 
+            whatsapp_tag_condition = '$Keywords=~/whatsapp/i or $XMP:Subject=~/whatsapp/i'
             cmd = [
                 'exiftool', vflag,
-                '-if','$Keywords=~/whatsapp/i',
+                '-if', whatsapp_tag_condition,
                 '-if','not defined $CreateDate',
                 '-CreateDate<FileModifyDate',
                 '-overwrite_original_in_place','-P','-fast2',
@@ -1034,7 +1036,7 @@ def exif_sort(src, dest, args):
             queue(cmd, message=stage_message())
             cmd = [
                 'exiftool', vflag,
-                '-if','$Keywords=~/whatsapp/i',
+                '-if', whatsapp_tag_condition,
                 '-FileName<${CreateDate} ${Keywords}%-c.%e',
                 '-d', "%Y-%m-%d %H-%M-%S",
                 '-ext+','JPG','-ext+','MP4','-ext+','3GP'
@@ -1042,7 +1044,7 @@ def exif_sort(src, dest, args):
             queue(cmd, message=stage_message())
             cmd = [
                 'exiftool', vflag,
-                '-if','$Keywords=~/whatsapp/i',
+                '-if', whatsapp_tag_condition,
                 '-Directory<$CreateDate/WhatsApp',
                 '-d', f"{dest}/{ym}", '-Filename=%f%-c.%e'
             ]


### PR DESCRIPTION
## Summary
- ensure the WhatsApp video exiftool command also populates the XMP subject tag that MP4/MOV files support
- update downstream WhatsApp exiftool filters to match either the legacy Keywords value or the new XMP subject tag

## Testing
- python3 rog-syncobra.py --whatsapp -m /tmp/whatsapp_dest --inputdir /tmp/whatsapp_test


------
https://chatgpt.com/codex/tasks/task_e_68d6a0d281b88325839ecec8b09530e4