### PR TITLE
Combine metadata and raw dedupe passes

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -565,7 +565,10 @@ def check_year_mount(dest):
 def xxrdfind_dedupe(paths, dry_run=False, strip_metadata=False, delete_within=None):
     path_strings = [str(p) for p in paths]
     details = []
-    if strip_metadata:
+    mode = strip_metadata
+    if isinstance(mode, str) and mode == 'both':
+        details.append('metadata+raw')
+    elif mode:
         details.append('strip_metadata')
     delete_within_strings = [str(root) for root in delete_within] if delete_within else []
     threads = XXRDFIND_CONFIG.get('threads')
@@ -629,8 +632,10 @@ def raw_dedupe(src, dest, dry_run=False, *_, **__):
         paths.append(dest_abs)
     paths.append(src_abs)
     prefix = "[DRY] " if dry_run else ""
-    logger.info(f"{prefix}Raw dedupe via xxrdfind: {' '.join(paths)}")
-    xxrdfind_dedupe(paths, dry_run=dry_run, strip_metadata=True)
+    logger.info(
+        f"{prefix}Raw dedupe via xxrdfind (including metadata pass): {' '.join(paths)}"
+    )
+    xxrdfind_dedupe(paths, dry_run=dry_run, strip_metadata='both')
 
 def exif_sort(src, dest, args):
     cwd = os.getcwd()


### PR DESCRIPTION
## Summary
- add support in `xxrdfind.find_duplicates` for running metadata and raw dedupe in a single scan
- update rog-syncobra raw dedupe to automatically include a metadata dedupe pass
- improve logging to reflect combined dedupe behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d8255571d883259496da17e4a79c24