### PR TITLE
Replace inotify watch mode with watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The script relies on a few external programs:
 
 - `libimage-exiftool-perl` (provides `exiftool`)
 - `xxhash` (provides `xxhsum`)
-- `inotify-tools` (required only for `--watch` mode)
+- `watchdog` Python package (install via `pip install watchdog` or the `python3-watchdog`
+  package; required only for `--watch` mode)
 - standard Unix tools such as `sort`, `du` and `df`
 
 For metadata or raw-data deduplication an internal script `xxrdfind.py`


### PR DESCRIPTION
## Summary
- replace the shell `inotifywait` dependency with a watchdog-based watcher implementation
- document and auto-install the new Python dependency for watch mode
- update the unit tests to exercise the new watcher helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9aeb51dcc83259096d2878fb989d4