### PR TITLE
Broaden CreationDate guard to handle QuickTime tags

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1159,22 +1159,39 @@ def exif_sort(src, dest, args):
             '-ext', 'vob',
         ]
         queue(cmd, message="Misc vid processing")
-        cmd = [
+        dcim_common = [
             'exiftool', vflag,
             '-if','not defined $Keywords',
             '-if','not defined $Keys:Keywords',
-            '-Filename<${ModifyDate}%-c.%e',
-            '-Filename<${DateTimeOriginal}%-c.%e',
-            '-Filename<${CreateDate}%-c.%e',
-            '-Filename<${CreateDate} ${model}%-c.%e',
-            '-Filename<${CreationDate} ${model}%-c.%e',
-            '-Filename<${CreateDate}_$SubSecTimeOriginal ${model}%-c.%e',
-            '-Filename<${CreationDate}_$SubSecTimeOriginal ${model}%-c.%e',
             '-d', f"{dest}/{ym}/%Y-%m-%d %H-%M-%S",
             '-ext+','mpg','-ext+','MTS','-ext+','VOB','-ext+','3GP','-ext+','AVI',
             '-ee'
         ]
+
+        cmd = [
+            *dcim_common,
+            '-Filename<${ModifyDate}%-c.%e',
+            '-Filename<${DateTimeOriginal}%-c.%e',
+            '-Filename<${CreateDate}%-c.%e',
+            '-Filename<${CreateDate} ${model}%-c.%e',
+            '-Filename<${CreateDate}_$SubSecTimeOriginal ${model}%-c.%e',
+        ]
         queue(cmd, message="DCIM processing")
+
+        creation_date_condition = (
+            'defined $CreationDate or defined $QuickTime:CreationDate '
+            'or defined $QuickTime:CreateDate'
+        )
+        creation_date_tag = (
+            '${CreationDate;QuickTime:CreationDate;QuickTime:CreateDate}'
+        )
+        creation_date_cmd = [
+            *dcim_common,
+            '-if', creation_date_condition,
+            f'-Filename<{creation_date_tag} ${{model}}%-c.%e',
+            f'-Filename<{creation_date_tag}_$SubSecTimeOriginal ${{model}}%-c.%e',
+        ]
+        queue(creation_date_cmd)
         cmd = [
             'exiftool', vflag,
             '-if','not defined $Keywords and not defined $Keys:Keywords and not defined $model;',

--- a/test_exif_sort.py
+++ b/test_exif_sort.py
@@ -130,6 +130,108 @@ def test_exif_sort_configures_stay_open_ready(monkeypatch, tmp_path):
         assert "-echo3\n{ready}\n-execute\n" in write
 
 
+def _extract_stay_open_payloads(instances):
+    payloads = []
+    for proc in instances:
+        stdin = getattr(proc, "stdin", None)
+        if stdin is None:
+            continue
+        for write in getattr(stdin, "writes", []):
+            if "-echo3\n" not in write:
+                continue
+            before_marker, *_ = write.split("\n-echo3\n", 1)
+            payloads.append(before_marker.split("\n"))
+    return payloads
+
+
+def test_exif_sort_guards_creation_date_commands(monkeypatch, tmp_path):
+    instances = []
+
+    def fake_scan_media_extensions(*_args, **_kwargs):
+        return {".jpg"}
+
+    monkeypatch.setattr(MODULE, "scan_media_extensions", fake_scan_media_extensions)
+    monkeypatch.setattr(MODULE, "SCREENSHOT_EXTS", {".png"})
+
+    class DummyStdout:
+        def __init__(self):
+            self.lines = deque()
+
+        def push_ready(self):
+            self.lines.append("{ready}\n")
+
+        def readline(self):
+            if not self.lines:
+                raise AssertionError("No output queued for exiftool mock")
+            return self.lines.popleft()
+
+    class DummyStdin:
+        def __init__(self, stdout):
+            self.stdout = stdout
+            self.writes = []
+
+        def write(self, data: str):
+            self.writes.append(data)
+            ready_count = data.count("-echo3\n")
+            for _ in range(ready_count):
+                self.stdout.push_ready()
+            return len(data)
+
+        def flush(self):
+            return None
+
+    class DummyProc:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.stdout = DummyStdout()
+            self.stdin = DummyStdin(self.stdout)
+
+        def communicate(self, *args, **kwargs):
+            return ("", "")
+
+        def poll(self):
+            return None
+
+        def kill(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        proc = DummyProc(*args, **kwargs)
+        instances.append(proc)
+        return proc
+
+    monkeypatch.setattr(MODULE.subprocess, "Popen", fake_popen)
+
+    (tmp_path / "sample.JPG").write_bytes(b"")
+    args = types.SimpleNamespace(
+        debug=False,
+        year_month_sort=False,
+        skip_marker=None,
+        recursive=False,
+        whatsapp=False,
+        dry_run=False,
+        min_age_days=0,
+    )
+
+    result = MODULE.exif_sort(str(tmp_path), str(tmp_path), args)
+    assert result is True
+
+    payloads = _extract_stay_open_payloads(instances)
+    # Ensure that creation-date based renames are gated by a defined check
+    creation_payloads = [payload for payload in payloads if any("${CreationDate" in part for part in payload)]
+    assert creation_payloads, "Creation-date rename commands were not queued"
+    for payload in creation_payloads:
+        assert any('defined $CreationDate' in part for part in payload), payload
+        assert any('QuickTime:CreationDate' in part for part in payload), payload
+        assert any(
+            part.startswith('-Filename<${CreationDate;QuickTime:CreationDate;QuickTime:CreateDate}')
+            for part in payload
+        ), payload
+
+    base_payloads = [payload for payload in payloads if any("${CreateDate}_$SubSecTimeOriginal" in part for part in payload)]
+    assert base_payloads, "CreateDate rename command missing"
+
 @pytest.mark.parametrize(
     "warning_message",
     [


### PR DESCRIPTION
## Summary
- extend the CreationDate rename guard to recognize QuickTime-specific tags when queueing DCIM processing
- assert that the stay-open payload includes the QuickTime guard and alias-based filename rewrite in the tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbb36f46a8832584a481fb85ee3147