### PR TITLE
Ensure pipelines run sequentially to avoid missed files

### DIFF
--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -1,0 +1,28 @@
+import importlib.util
+import threading
+from types import SimpleNamespace
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("rog-syncobra.py")
+SPEC = importlib.util.spec_from_file_location("rog_syncobra_pipeline", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_run_pipelines_sequential(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def fake_pipeline(args, src):
+        calls.append((src, threading.current_thread().name))
+
+    monkeypatch.setattr(MODULE, "pipeline", fake_pipeline)
+
+    args = SimpleNamespace(move2targetdir=None, dry_run=False)
+    sources = ["/path/one", "/path/two", "/path/three"]
+
+    MODULE._run_pipelines(args, sources)
+
+    assert [src for src, _ in calls] == sources
+    thread_names = {name for _, name in calls}
+    assert thread_names == {threading.current_thread().name}


### PR DESCRIPTION
## Summary
- process input directories sequentially to prevent race conditions that skipped files when pipelines shared destinations
- add a regression test confirming that `_run_pipelines` executes sequentially in the calling thread

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc389536fc83258b7c15fe1fce7964