### PR TITLE
Add xxrdfind cache cleanup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ For metadata or raw-data deduplication an internal script `xxrdfind.py`
 external `rdfind` utility. Using its `--strip-metadata` option allows
 deduplication based solely on media content.
 
+If cached hashes become stale you can remove them with the helper
+`xxrdfind_cache_tool.py`. Run it against one or more directories to delete all
+`.xxrdfind_cache*.json` files, optionally with `--recursive` to walk subdirectories
+or `--dry-run` to preview the actions:
+
+```bash
+./xxrdfind_cache_tool.py --recursive /srv/media/incoming
+```
+
 To automatically install missing packages run:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -137,6 +137,7 @@ SCRIPT_FILES=(
     "rog-syncobra.py"
     "photoprism-watcher.py"
     "xxrdfind.py"
+    "xxrdfind_cache_tool.py"
 )
 MODULE_FILES=(
     "photoprism_api.py"

--- a/test_xxrdfind_cache_tool.py
+++ b/test_xxrdfind_cache_tool.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("xxrdfind_cache_tool.py")
+SPEC = importlib.util.spec_from_file_location("xxrdfind_cache_tool", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_dry_run_reports_all_cache_files(tmp_path):
+    cache_root = tmp_path / "root"
+    cache_root.mkdir()
+    files = [
+        cache_root / ".xxrdfind_cache.json",
+        cache_root / ".xxrdfind_cache_stripped.json",
+    ]
+    for file in files:
+        file.write_text("{}")
+
+    removed = MODULE.remove_cache_files([str(cache_root)], dry_run=True)
+
+    assert removed == len(files)
+    for file in files:
+        assert file.exists()
+
+
+def test_recursive_removal(tmp_path):
+    cache_root = tmp_path / "root"
+    nested = cache_root / "nested"
+    nested.mkdir(parents=True)
+    files = [
+        cache_root / ".xxrdfind_cache.json",
+        nested / ".xxrdfind_cache.json",
+        nested / ".xxrdfind_cache_stripped.json",
+    ]
+    for file in files:
+        file.write_text("{}")
+
+    removed = MODULE.remove_cache_files([str(cache_root)], recursive=True)
+
+    assert removed == len(files)
+    for file in files:
+        assert not file.exists()

--- a/xxrdfind.py
+++ b/xxrdfind.py
@@ -49,6 +49,14 @@ UNSUPPORTED_EXIFTOOL_VIDEO_EXTENSIONS = {
 
 logger = logging.getLogger("xxrdfind")
 
+CACHE_SUFFIXES = ('', '_stripped')
+
+
+def cache_files_for_root(root: Path) -> list[Path]:
+    """Return all cache file paths that xxrdfind may create under *root*."""
+
+    return [root / f'.xxrdfind_cache{suffix}.json' for suffix in CACHE_SUFFIXES]
+
 
 @dataclass
 class DuplicateSummary:
@@ -89,8 +97,7 @@ def save_cache(root: Path, cache: dict, strip_metadata: bool) -> None:
 
 
 def remove_cache(root: Path) -> None:
-    for suffix in ('', '_stripped'):
-        cache_path = root / f'.xxrdfind_cache{suffix}.json'
+    for cache_path in cache_files_for_root(root):
         try:
             cache_path.unlink()
             logger.info("Removed cache %s", cache_path)

--- a/xxrdfind_cache_tool.py
+++ b/xxrdfind_cache_tool.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Utility to remove cached hashes produced by :mod:`xxrdfind`."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import xxrdfind
+
+logger = logging.getLogger("xxrdfind-cache-tool")
+CACHE_FILENAMES = tuple(path.name for path in xxrdfind.cache_files_for_root(Path(".")))
+
+
+def _normalize_path(raw: str) -> Path:
+    return Path(raw).expanduser().resolve()
+
+
+def _discover_cache_files(root: Path, recursive: bool) -> set[Path]:
+    caches: set[Path] = set()
+    if not root.exists():
+        logger.warning("Skipping %s (does not exist)", root)
+        return caches
+    if not root.is_dir():
+        logger.warning("Skipping %s (not a directory)", root)
+        return caches
+
+    if recursive:
+        for name in CACHE_FILENAMES:
+            for candidate in root.rglob(name):
+                if candidate.is_file():
+                    caches.add(candidate)
+    else:
+        for cache_path in xxrdfind.cache_files_for_root(root):
+            if cache_path.is_file():
+                caches.add(cache_path)
+
+    return caches
+
+
+def remove_cache_files(paths: Iterable[str], recursive: bool = False, dry_run: bool = False) -> int:
+    """Remove xxrdfind cache files under ``paths``.
+
+    Returns the number of cache files that were removed (or would be removed
+    during a dry-run).
+    """
+
+    seen: set[Path] = set()
+    removed = 0
+    for raw in paths:
+        root = _normalize_path(raw)
+        caches = _discover_cache_files(root, recursive)
+        if not caches:
+            logger.debug("No caches found under %s", root)
+        for cache_path in sorted(caches):
+            if cache_path in seen:
+                continue
+            seen.add(cache_path)
+            if dry_run:
+                logger.info("Would remove %s", cache_path)
+                removed += 1
+                continue
+            try:
+                cache_path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning("Failed to remove %s: %s", cache_path, exc)
+            else:
+                logger.info("Removed %s", cache_path)
+                removed += 1
+    return removed
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Remove xxrdfind cache files (.xxrdfind_cache*.json)."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["."],
+        help="Directories to scan (default: current directory)",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Scan directories recursively",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Show which files would be removed without deleting them",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only print warnings and errors",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_logging(verbose: bool, quiet: bool) -> None:
+    if quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.verbose, args.quiet)
+    removed = remove_cache_files(args.paths, recursive=args.recursive, dry_run=args.dry_run)
+    if removed == 0:
+        message = "No cache files would be removed" if args.dry_run else "No cache files removed"
+        logger.info(message)
+    else:
+        message = "Would remove %d cache file%s" if args.dry_run else "Removed %d cache file%s"
+        plural = "s" if removed != 1 else ""
+        logger.info(message, removed, plural)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an xxrdfind_cache_tool.py helper that deletes .xxrdfind_cache*.json files with recursive and dry-run support
- expose cache file helpers inside xxrdfind and install the new script via install.sh
- document the cache cleanup tool and cover it with dedicated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc509ed0408325bbdac6939441de13