### PR TITLE
Rename WhatsApp images using modify timestamp

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1247,6 +1247,15 @@ def exif_sort(src, dest, args):
         queue(
             _exiftool_cmd(
                 *_conditional_args(image_condition),
+                '-FileName<${FileModifyDate} WhatsApp%-c.%e',
+                '-d', "%Y-%m-%d %H-%M-%S",
+                '-ext+','JPG','-ext+','JPEG'
+            ),
+            message=stage_message(),
+        )
+        queue(
+            _exiftool_cmd(
+                *_conditional_args(image_condition),
                 '-Directory<$FileModifyDate/WhatsApp',
                 '-d', f"{dest}/{ym}", '-Filename=%f%-c.%e',
                 '-ext+','JPG','-ext+','JPEG'


### PR DESCRIPTION
## Summary
- ensure WhatsApp JPG/JPEG files are renamed to include the modify timestamp and suffix

## Testing
- pytest test_exif_sort.py -k whatsapp

------
https://chatgpt.com/codex/tasks/task_e_68dcd7ce3ae48325a57ac4bae0031484