### PR TITLE
Ensure strip-metadata hashes all files

### DIFF
--- a/xxrdfind.py
+++ b/xxrdfind.py
@@ -305,10 +305,20 @@ def find_duplicates(paths, delete=False, dry_run=False, threads=None, show_progr
             all_files.append((f, root_cache, stat))
             size_groups[stat.st_size].append(f)
 
-        hash_candidates = [entry for entry in all_files if len(size_groups[entry[2].st_size]) > 1]
-        if logger.isEnabledFor(logging.DEBUG):
-            skipped = len(all_files) - len(hash_candidates)
-            logger.debug("Skipping hashing for %d files with unique sizes", skipped)
+        if strip_flag:
+            hash_candidates = all_files
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "strip_metadata enabled; hashing all %d files regardless of size",
+                    len(all_files),
+                )
+        else:
+            hash_candidates = [
+                entry for entry in all_files if len(size_groups[entry[2].st_size]) > 1
+            ]
+            if logger.isEnabledFor(logging.DEBUG):
+                skipped = len(all_files) - len(hash_candidates)
+                logger.debug("Skipping hashing for %d files with unique sizes", skipped)
 
         hash_map: defaultdict[str, list[Path]] = defaultdict(list)
         worker_count = threads if threads and threads > 0 else (os.cpu_count() or 1)


### PR DESCRIPTION
## Summary
- hash every file when running the strip-metadata pass so unique file sizes are considered
- add a regression test to ensure strip-metadata hashing covers uniquely-sized files

## Testing
- pytest test_xxrdfind.py

------
https://chatgpt.com/codex/tasks/task_e_68dd162991208325850a0ad3a6f06d97