### PR TITLE
Ensure camera model renames require Model metadata

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1284,7 +1284,7 @@ def exif_sort(src, dest, args):
         )
         cmd = _exiftool_cmd(
             '-if', whatsapp_keyword_guard,
-            '-if', 'not defined $model',
+            '-if', 'not defined $Model',
             "-FileName<${FileModifyDate}%-c.%e",
             '-d', f"{dest}/{ym}/%Y-%m-%d %H-%M-%S",
             '-ext', 'mp4',
@@ -1321,8 +1321,8 @@ def exif_sort(src, dest, args):
             [
                 *dcim_common,
                 '-if',
-                f'defined $model and ({timestamp_condition})',
-                f'-Filename<{timestamp_tag} ${{model}}%-c.%e',
+                f'defined $Model and ({timestamp_condition})',
+                f'-Filename<{timestamp_tag} ${{Model}}%-c.%e',
             ],
         )
 
@@ -1330,8 +1330,8 @@ def exif_sort(src, dest, args):
             [
                 *dcim_common,
                 '-if',
-                f'defined $SubSecTimeOriginal and ({timestamp_condition})',
-                f'-Filename<{timestamp_tag}_$SubSecTimeOriginal ${{model}}%-c.%e',
+                f'defined $Model and defined $SubSecTimeOriginal and ({timestamp_condition})',
+                f'-Filename<{timestamp_tag}_$SubSecTimeOriginal ${{Model}}%-c.%e',
             ],
         )
 
@@ -1345,14 +1345,14 @@ def exif_sort(src, dest, args):
         )
         creation_date_cmd = [
             *dcim_common,
-            '-if', creation_date_condition,
-            f'-Filename<{creation_date_tag} ${{model}}%-c.%e',
-            f'-Filename<{creation_date_tag}_$SubSecTimeOriginal ${{model}}%-c.%e',
+            '-if', f'defined $Model and ({creation_date_condition})',
+            f'-Filename<{creation_date_tag} ${{Model}}%-c.%e',
+            f'-Filename<{creation_date_tag}_$SubSecTimeOriginal ${{Model}}%-c.%e',
 
         ]
         queue(creation_date_cmd)
         cmd = _exiftool_cmd(
-            '-if', f'{whatsapp_keyword_guard} and not defined $model;',
+            '-if', f'{whatsapp_keyword_guard} and not defined $Model',
             '-if', f'not {WHATSAPP_ANY_IF_CLAUSE}',
             '-Directory<$FileModifyDate/diverses',
             '-d', f"{dest}/{ym}", '-Filename=%f%-c.%e'

--- a/test_exif_sort.py
+++ b/test_exif_sort.py
@@ -321,6 +321,14 @@ def test_exif_sort_guards_creation_date_commands(monkeypatch, tmp_path):
         ]
         assert 'JPG' in extensions, payload
 
+    model_payloads = [
+        payload for payload in payloads if any('${Model}' in part for part in payload)
+    ]
+    assert model_payloads, 'Camera model rename command missing'
+    for payload in model_payloads:
+        assert any('defined $Model' in part for part in payload), payload
+        assert any('${Model}%-c.%e' in part for part in payload), payload
+
     # Ensure that creation-date based renames are gated by a defined check
 
     creation_payloads = [payload for payload in payloads if any("${CreationDate" in part for part in payload)]


### PR DESCRIPTION
## Summary
- switch DCIM rename logic to rely on the proper `Model` tag casing so JPEGs with camera metadata are renamed
- guard model-based filename templates with explicit Model checks and extend tests to assert the commands are queued

## Testing
- pytest test_exif_sort.py

------
https://chatgpt.com/codex/tasks/task_e_68dda561df5483259777f235827d6578