### PR TITLE
Prioritize camera metadata when renaming DCIM media

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1311,8 +1311,8 @@ def exif_sort(src, dest, args):
             [
                 *dcim_common,
                 '-if',
-                timestamp_condition,
-                f'-Filename<{timestamp_tag}%-c.%e',
+                f'defined $Model and defined $SubSecTimeOriginal and ({timestamp_condition})',
+                f'-Filename<{timestamp_tag}_$SubSecTimeOriginal ${{Model}}%-c.%e',
             ],
             message="DCIM processing",
         )
@@ -1330,8 +1330,8 @@ def exif_sort(src, dest, args):
             [
                 *dcim_common,
                 '-if',
-                f'defined $Model and defined $SubSecTimeOriginal and ({timestamp_condition})',
-                f'-Filename<{timestamp_tag}_$SubSecTimeOriginal ${{Model}}%-c.%e',
+                f'(not defined $Model or $Model eq "") and ({timestamp_condition})',
+                f'-Filename<{timestamp_tag}%-c.%e',
             ],
         )
 

--- a/test_exif_sort.py
+++ b/test_exif_sort.py
@@ -313,13 +313,14 @@ def test_exif_sort_guards_creation_date_commands(monkeypatch, tmp_path):
     ]
     assert dcim_payloads, "DCIM rename commands were not queued"
     for payload in dcim_payloads:
-        assert timestamp_condition in payload
+        assert any(timestamp_condition in part for part in payload)
         extensions = [
             payload[idx + 1]
             for idx in range(len(payload) - 1)
             if payload[idx] in ('-ext', '-ext+')
         ]
         assert 'JPG' in extensions, payload
+        assert any('not defined $Model or $Model eq ""' in part for part in payload), payload
 
     model_payloads = [
         payload for payload in payloads if any('${Model}' in part for part in payload)


### PR DESCRIPTION
## Summary
- run the DCIM rename command that uses camera model and sub-second metadata before the generic fallback
- ensure the generic timestamp-only rename only targets files missing camera model metadata
- extend the DCIM rename test to assert the new guard and tolerate the updated condition layout

## Testing
- pytest test_exif_sort.py

------
https://chatgpt.com/codex/tasks/task_e_68ddaa8ea47883258c89a9752f48319b