### PR TITLE
Fix WhatsApp guard to allow camera rename

### DIFF
--- a/rog-syncobra.py
+++ b/rog-syncobra.py
@@ -1280,7 +1280,11 @@ def exif_sort(src, dest, args):
     if dcim_present:
         dcim_ext_filters = build_exiftool_extension_filters(DCIM_EXTS - HEIC_EXTS)
         whatsapp_keyword_guard = (
-            'not ($Keywords=~/whatsapp/i or $Keys:Keywords=~/whatsapp/i)'
+            'not ('
+            ' (defined $Keywords and $Keywords=~/whatsapp/i)'
+            ' or (defined $Keys:Keywords and $Keys:Keywords=~/whatsapp/i)'
+            ' or (defined $XMP:Subject and $XMP:Subject=~/whatsapp/i)'
+            ')'
         )
         cmd = _exiftool_cmd(
             '-if', whatsapp_keyword_guard,

--- a/test_exif_sort.py
+++ b/test_exif_sort.py
@@ -321,6 +321,14 @@ def test_exif_sort_guards_creation_date_commands(monkeypatch, tmp_path):
         ]
         assert 'JPG' in extensions, payload
         assert any('not defined $Model or $Model eq ""' in part for part in payload), payload
+        guard = (
+            'not ('
+            ' (defined $Keywords and $Keywords=~/whatsapp/i)'
+            ' or (defined $Keys:Keywords and $Keys:Keywords=~/whatsapp/i)'
+            ' or (defined $XMP:Subject and $XMP:Subject=~/whatsapp/i)'
+            ')'
+        )
+        assert any(guard in part for part in payload), payload
 
     model_payloads = [
         payload for payload in payloads if any('${Model}' in part for part in payload)


### PR DESCRIPTION
## Summary
- ensure the WhatsApp keyword guard checks for tag presence before evaluating the regex
- extend unit coverage to assert the refined guard is used for DCIM renames

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de59db68c083258be145f74209345f